### PR TITLE
Fix recommendations example dict by adding missing comma

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.1
+current_version = 0.2.2
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.2] - 2021-11-3
+
+### Fixed
+
+* The `settings.json` file that was output by `pydev` was malformed, and this patch ensures that's no longer the case.
+
 ## [0.2.1] - 2021-10-10
 
 ### Added

--- a/devwrangler/__init__.py
+++ b/devwrangler/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Nick Cannariato"""
 __email__ = 'devrel@birdcar.dev'
-__version__ = '0.2.1'
+__version__ = '0.2.2'

--- a/devwrangler/devwrangler.py
+++ b/devwrangler/devwrangler.py
@@ -54,7 +54,8 @@ DEFAULT_VSCODE_CONFIG = {
     "python.sortImports.args": ["--profile", "black"],
     "recommendations": [
         "ms-python.python",
-        "ms-python.vscode-pylance" "hbenl.vscode-test-explorer",
+        "ms-python.vscode-pylance",
+        "hbenl.vscode-test-explorer",
         "littlefoxteam.vscode-python-test-adapter",
         "ms-vscode.test-adapter-converter",
         "samuelcolvin.jinjahtml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "devwrangler"
-version = "0.2.1"
+version = "0.2.2"
 homepage = "https://github.com/birdcar/devwrangler"
 description = "Bringing peace, freedom, justice, and security to your Python empire."
 authors = ["Nick Cannariato <devrel@birdcar.dev>"]


### PR DESCRIPTION
This PR fixes a missing comma in the settings.json file, noticed in #3.

This does not completely fix #3, but it prevents the `settings.json` file from being unreadable by VS Code when it's generated.

The final fix for #3 is going to be in a future PR when we refactor how the config data is generated and introduce Jinja.